### PR TITLE
Add Gradio SVG converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# animal-svg-converter
+# Animal SVG Converter
+
+A simple Gradio app to convert images to SVG using vtracer.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the app:
+   ```bash
+   python app.py
+   ```
+3. Open the provided URL in your browser and upload images to convert them to SVG.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,51 @@
+import gradio as gr
+import vtracer
+import os
+import tempfile
+
+# Convert a single image to SVG and return path
+
+def convert_image(image_path, output_dir):
+    base = os.path.splitext(os.path.basename(image_path))[0]
+    svg_path = os.path.join(output_dir, f"{base}.svg")
+    vtracer.convert_image_to_svg_py(image_path, svg_path)
+    return svg_path
+
+
+def convert_images_to_svgs(files):
+    """Convert uploaded images to SVG and return list of SVG file paths."""
+    if not files:
+        return []
+
+    output_dir = tempfile.mkdtemp()
+    svg_paths = []
+    for file_obj in files:
+        if hasattr(file_obj, 'name'):
+            path = file_obj.name
+        else:
+            path = file_obj
+        svg_path = convert_image(path, output_dir)
+        svg_paths.append(svg_path)
+
+    return svg_paths
+
+
+def build_app():
+    with gr.Blocks() as demo:
+        gr.Markdown("## Image to SVG Converter")
+        gr.Markdown("Upload multiple images and download converted SVG files.")
+        with gr.Row():
+            inp = gr.File(file_count="multiple", label="Input Images")
+        out_files = gr.Files(label="Converted SVGs")
+        btn = gr.Button("Convert")
+        btn.click(fn=convert_images_to_svgs, inputs=inp, outputs=out_files)
+    return demo
+
+
+def main():
+    demo = build_app()
+    demo.launch()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+gradio
+vtracer


### PR DESCRIPTION
## Summary
- add Gradio app to convert images to SVG using vtracer
- add dependency requirements
- update README with usage instructions

## Testing
- `pip install vtracer`


------
https://chatgpt.com/codex/tasks/task_e_684d6d69d09c832ca824a966d25a834a