### PR TITLE
Add background removal option and preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Animal SVG Converter
 
 A simple Gradio app to convert images to SVG using vtracer.
+It can optionally remove the largest element from each SVG (useful for
+removing background rectangles) and provides a preview of the conversion.
 
 ## Usage
 

--- a/app.py
+++ b/app.py
@@ -2,32 +2,93 @@ import gradio as gr
 import vtracer
 import os
 import tempfile
+import xml.etree.ElementTree as ET
+import re
+
+# Helper to estimate area of a path by bounding box
+def _path_area(path_data):
+    coords = re.findall(r"(-?\d+\.?\d*)[, ]+(-?\d+\.?\d*)", path_data)
+    if not coords:
+        return 0
+    xs = [float(x) for x, _ in coords]
+    ys = [float(y) for _, y in coords]
+    return (max(xs) - min(xs)) * (max(ys) - min(ys))
+
+
+def remove_largest_path(svg_file):
+    """Remove the path with the largest bounding box area from an SVG."""
+    try:
+        tree = ET.parse(svg_file)
+    except Exception:
+        return
+
+    root = tree.getroot()
+    paths = root.findall('.//{http://www.w3.org/2000/svg}path')
+    if not paths:
+        paths = root.findall('.//path')
+
+    largest = None
+    largest_area = 0
+    for p in paths:
+        area = _path_area(p.get('d', ''))
+        if area > largest_area:
+            largest_area = area
+            largest = p
+
+    if largest is None:
+        return
+
+    parent = None
+    for elem in root.iter():
+        for child in list(elem):
+            if child is largest:
+                parent = elem
+                break
+
+    if parent is not None:
+        parent.remove(largest)
+        tree.write(svg_file)
 
 # Convert a single image to SVG and return path
 
-def convert_image(image_path, output_dir):
+def convert_image(image_path, output_dir, remove_bg=False):
     base = os.path.splitext(os.path.basename(image_path))[0]
     svg_path = os.path.join(output_dir, f"{base}.svg")
     vtracer.convert_image_to_svg_py(image_path, svg_path)
+    if remove_bg:
+        remove_largest_path(svg_path)
     return svg_path
 
 
-def convert_images_to_svgs(files):
-    """Convert uploaded images to SVG and return list of SVG file paths."""
+def make_preview_html(original, converted):
+    """Return HTML snippet showing original and converted images."""
+    return (
+        f'<div style="display:flex;gap:10px;margin-bottom:1em">'
+        f'<div><p>Original</p><img src="file://{original}" style="max-width:200px"></div>'
+        f'<div><p>Converted</p><img src="file://{converted}" style="max-width:200px"></div>'
+        f'</div>'
+    )
+
+
+def convert_images_to_svgs(files, remove_bg=False):
+    """Convert uploaded images to SVG and return file paths and preview HTML."""
     if not files:
-        return []
+        return [], ""
 
     output_dir = tempfile.mkdtemp()
     svg_paths = []
+    previews = []
     for file_obj in files:
         if hasattr(file_obj, 'name'):
             path = file_obj.name
         else:
             path = file_obj
-        svg_path = convert_image(path, output_dir)
+        svg_path = convert_image(path, output_dir, remove_bg=remove_bg)
         svg_paths.append(svg_path)
+        previews.append(make_preview_html(path, svg_path))
 
-    return svg_paths
+    preview_html = "\n".join(previews)
+    return svg_paths, preview_html
 
 
 def build_app():
@@ -36,9 +97,11 @@ def build_app():
         gr.Markdown("Upload multiple images and download converted SVG files.")
         with gr.Row():
             inp = gr.File(file_count="multiple", label="Input Images")
+            remove_bg = gr.Checkbox(label="Remove largest element", value=False)
         out_files = gr.Files(label="Converted SVGs")
+        preview = gr.HTML()
         btn = gr.Button("Convert")
-        btn.click(fn=convert_images_to_svgs, inputs=inp, outputs=out_files)
+        btn.click(fn=convert_images_to_svgs, inputs=[inp, remove_bg], outputs=[out_files, preview])
     return demo
 
 


### PR DESCRIPTION
## Summary
- support removing the largest path from each SVG after conversion
- show a preview of original vs converted images
- document new feature in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684d6f900914832c8f96644013a76285